### PR TITLE
fix: select exclude exhausted lots option in modal

### DIFF
--- a/client/src/js/services/PeriodService.js
+++ b/client/src/js/services/PeriodService.js
@@ -1,72 +1,72 @@
 angular.module('bhima.services')
-.service('PeriodService', PeriodService);
+  .service('PeriodService', PeriodService);
 
 PeriodService.$inject = ['moment'];
 
 /** @TODO rewrite this using AMD synatx so that the same file can be used across
  *        the client and the server */
 function PeriodService(Moment) {
-  var service = this;
+  const service = this;
 
   /** @const */
-  var periods = {
+  const periods = {
     today : {
       key : 'today',
       translateKey : 'PERIODS.TODAY',
-      limit : calculatePeriodLimit('date')
+      limit : calculatePeriodLimit('date'),
     },
     week : {
       key : 'week',
       translateKey : 'PERIODS.THIS_WEEK',
-      limit : calculatePeriodLimit('week')
+      limit : calculatePeriodLimit('week'),
     },
     month : {
       key : 'month',
       translateKey : 'PERIODS.THIS_MONTH',
-      limit : calculatePeriodLimit('month')
+      limit : calculatePeriodLimit('month'),
     },
     year : {
       key : 'year',
       translateKey : 'PERIODS.THIS_YEAR',
-      limit : calculatePeriodLimit('year')
+      limit : calculatePeriodLimit('year'),
     },
     yesterday : {
       key : 'yesterday',
       translateKey : 'PERIODS.YESTERDAY',
-      limit : calculatePeriodLimit('date', -1)
+      limit : calculatePeriodLimit('date', -1),
     },
     lastWeek : {
       key : 'lastWeek',
       translateKey : 'PERIODS.LAST_WEEK',
-      limit : calculatePeriodLimit('week', -1)
+      limit : calculatePeriodLimit('week', -1),
     },
     lastMonth : {
       key : 'lastMonth',
       translateKey : 'PERIODS.LAST_MONTH',
-      limit : calculatePeriodLimit('month', -1)
+      limit : calculatePeriodLimit('month', -1),
     },
     lastYear : {
       key : 'lastYear',
       translateKey : 'PERIODS.LAST_YEAR',
-      limit : calculatePeriodLimit('year', -1)
+      limit : calculatePeriodLimit('year', -1),
     },
 
     // components will make an exception for all time - no period has to be selected
     // on the server this simple removes the WHERE condition
     allTime : {
       key : 'allTime',
-      translateKey : 'PERIODS.ALL_TIME'
+      translateKey : 'PERIODS.ALL_TIME',
     },
 
     custom : {
       key : 'custom',
-      translateKey : 'PERIODS.CUSTOM'
-    }
+      translateKey : 'PERIODS.CUSTOM',
+    },
   };
-  var categories = {
+  const categories = {
     THIS : [periods.today, periods.week, periods.month, periods.year],
     LAST : [periods.yesterday, periods.lastWeek, periods.lastMonth, periods.lastYear],
-    OTHER : [periods.allTime]
+    OTHER : [periods.allTime],
   };
 
   service.index = periods;
@@ -76,8 +76,8 @@ function PeriodService(Moment) {
   service.dateFormat = 'DD/MM/YYYY';
 
   function definition(key) {
-    var instance = angular.copy(periods[key]);
-    var calculate = instance.limit;
+    const instance = angular.copy(periods[key]);
+    const calculate = instance.limit;
 
     // make an exception for all time which does not have a defined limit
     if (calculate) {
@@ -88,21 +88,31 @@ function PeriodService(Moment) {
   }
 
   function calculatePeriodLimit(periodKey, modifier) {
-    var dateModifier = modifier || 0;
-    var currentPeriod = Moment().get(periodKey);
+    const dateModifier = modifier || 0;
+    const currentPeriod = Moment().get(periodKey);
 
     return {
-      start : function () { return Moment().set(periodKey, currentPeriod + dateModifier).startOf(periodKey).format(service.dateFormat); },
-      end : function () { return Moment().set(periodKey, currentPeriod + dateModifier).endOf(periodKey).format(service.dateFormat); }
-    }
+      start() {
+        return Moment()
+          .set(periodKey, currentPeriod + dateModifier)
+          .startOf(periodKey)
+          .format(service.dateFormat);
+      },
+      end() {
+        return Moment()
+          .set(periodKey, currentPeriod + dateModifier)
+          .endOf(periodKey)
+          .format(service.dateFormat);
+      },
+    };
   }
 
   // using these two methods gaurantees that period and custom period filters are never interchanged
 
   // returns an array of filters that should be applied given the new period selected
   // responsible for ensuring that custom period start and end are never included with the period filter
-  service.processFilterChanges = function processFilterChanges(period, periodKey, customStartKey, customEndKey) {
-    var periodChanges = [];
+  service.processFilterChanges = function processFilterChanges(period) {
+    const periodChanges = [];
 
     if (period === periods.custom) {
       // ensure period key is empty
@@ -121,16 +131,16 @@ function PeriodService(Moment) {
     }
 
     return periodChanges;
-  }
+  };
 
-  service.defaultFilters = function defaultFilters(periodKey, customStartKey, customEndKey) {
-    var defaultPeriod = periods.today;
+  service.defaultFilters = function defaultFilters() {
+    const defaultPeriod = periods.today;
     return [
       { key : 'period', value : defaultPeriod.key, displayValue : defaultPeriod.translateKey },
       { key : 'custom_period_start', value : null },
-      { key : 'custom_period_end', value : null }
+      { key : 'custom_period_end', value : null },
     ];
-  }
+  };
 
 // accepts a target array and an array of values, if any of the values are in the array
 }

--- a/client/src/modules/stock/StockFilterer.service.js
+++ b/client/src/modules/stock/StockFilterer.service.js
@@ -144,6 +144,12 @@ function StockFiltererService(Filters, AppCache, Periods, $httpParamSerializer, 
       if (assignedKeys.indexOf('limit') === -1) {
         this._filters.assignFilter('limit', 100);
       }
+
+      // assign default includeEmptyLot filter
+      if (assignedKeys.indexOf('includeEmptyLot') === -1) {
+        this._filters.assignFilter('includeEmptyLot', 0);
+      }
+
     }
 
     assignFilter(key, value) {

--- a/client/src/modules/stock/lots/modals/search.modal.js
+++ b/client/src/modules/stock/lots/modals/search.modal.js
@@ -97,7 +97,7 @@ function SearchLotsModalController(data, util, Store, Instance, Periods, Stock, 
     vm.defaultQueries.limit = data.limit;
   }
 
-  vm.cancel = function cancel() { Instance.close(); };
+  vm.cancel = () => Instance.dismiss();
 
   vm.submit = () => {
     const loggedChanges = SearchModal.getChanges(vm.searchQueries, changes, displayValues, lastDisplayValues);

--- a/client/src/modules/templates/bhStockFilterExhausted.tmpl.html
+++ b/client/src/modules/templates/bhStockFilterExhausted.tmpl.html
@@ -7,7 +7,7 @@
 
   <div>
     <div class="radio">
-      <label class="radio-inline">
+      <label class="radio-inline" data-exclude-exhausted-lots>
         <input
           type="radio"
           name="{{$ctrl.name}}"
@@ -20,7 +20,7 @@
     </div>
 
     <div class="radio">
-      <label class="radio-inline">
+      <label class="radio-inline" data-include-exhausted-lots>
         <input
           type="radio"
           name="{{$ctrl.name}}"
@@ -33,7 +33,7 @@
     </div>
 
     <div class="radio">
-      <label class="radio-inline">
+      <label class="radio-inline" data-include-only-exhausted-lots>
         <input
           type="radio"
           name="{{$ctrl.name}}"

--- a/test/end-to-end/stock/stock.z3.inventory-adjustment-lots.spec.js
+++ b/test/end-to-end/stock/stock.z3.inventory-adjustment-lots.spec.js
@@ -34,25 +34,34 @@ function StockLotsRegistryTests() {
     await GU.expectRowCount(gridId, GROUPING_ROW + LOT_FOR_ALLTIME);
   });
 
-  it('find only lots setted during the adjustment process', async () => {
+  it('find only lots set during the adjustment process', async () => {
     const quinine = {
       label : 'Quinine Bichlorhydrate, sirop, 100mg base/5ml, 100ml, flacon, Unité',
       lot : 'QUININE-B',
       quantity : '17',
     };
+
     const vitamine = {
       label : 'Vitamines B1+B6+B12, 100+50+0.5mg/2ml, Amp, Unité',
       lot : 'VITAMINE-B',
       quantity : '23',
     };
+
     await modal.setDepot('Depot Principal');
+
+    // set the default value for include/exclude exhausted lots.
+    await modal.switchToDefaultFilterTab();
+    await $('[data-exclude-exhausted-lots]').click();
+
     await modal.submit();
+
     await GU.expectCellValueMatch(gridId, 1, 2, vitamine.label);
     await GU.expectCellValueMatch(gridId, 1, 4, vitamine.lot);
     await GU.expectCellValueMatch(gridId, 1, 5, vitamine.quantity);
     await GU.expectCellValueMatch(gridId, 2, 2, quinine.label);
     await GU.expectCellValueMatch(gridId, 2, 4, quinine.lot);
     await GU.expectCellValueMatch(gridId, 2, 5, quinine.quantity);
+
     await filters.resetFilters();
   });
 }


### PR DESCRIPTION
Fixes the end to end tests by excluding the exhausted lots option before doing the filtering.